### PR TITLE
 provide output from getAllowedMethods()

### DIFF
--- a/Model/Carrier.php
+++ b/Model/Carrier.php
@@ -202,8 +202,7 @@ class Carrier extends \Magento\Shipping\Model\Carrier\AbstractCarrierOnline impl
 
     public function getAllowedMethods()
     {
-        // Does not need implementation
-        return [];
+        return $this->getMethods();
     }
 
     public function getTracking($tracking)


### PR DESCRIPTION
getAllowedMethods() is part of \Magento\Shipping\Model\Carrier\CarrierInterface and for this reason should return a valid result.
All the other Magento shipping methods output reliable information trough this interface.
Currently this shipping method is giving as output empty methods (providing a not reliable value).