### PR TITLE
Add required call this._super() in initObservable

### DIFF
--- a/view/frontend/web/js/view/deliveryoptions-info.js
+++ b/view/frontend/web/js/view/deliveryoptions-info.js
@@ -32,6 +32,7 @@ define([
         excludedServiceData: ko.observableArray([]),
 
         initObservable: function () {
+            this._super();
 
             var self = this;
             var postcode_memory = null;

--- a/view/frontend/web/js/view/servicepoint-info.js
+++ b/view/frontend/web/js/view/servicepoint-info.js
@@ -12,6 +12,7 @@ define([
         },
 
         initObservable: function () {
+            this._super();
 
             this.DHLParcel_Shipping_SelectedMethod = ko.computed(function() {
 


### PR DESCRIPTION
Call to `this._super()` is required to not break the functionality of the parent `collection` component (`uiComponent`)