### PR TITLE
Magento 2.4.4 compatibility

### DIFF
--- a/Logger/DebugLogger.php
+++ b/Logger/DebugLogger.php
@@ -24,7 +24,7 @@ class DebugLogger extends \Monolog\Logger
         $this->active = boolval($this->helper->getConfigData('debug/enabled'));
     }
 
-    public function addRecord($level, $message, array $context = [])
+    public function addRecord(int $level, string $message, array $context = []): bool
     {
         if (!$this->active) {
             return false;

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   ],
   "require": {
     "ext-json": "*",
-    "guzzlehttp/guzzle": "~6.0",
+    "guzzlehttp/guzzle": "~7.3",
     "setasign/fpdi-fpdf": "^2.0"
   },
   "autoload": {


### PR DESCRIPTION
As mentioned in #40 the current module is not compatible with Magneto 2.4.4. This PR aims to resolve that issue.

I've done some local testing, but have not had a chance for more extensive testing. If anyone else can confirm these changes that would be great.

**Changes:**
- Update required Guzzle version
- Fix method signature for Monolog Logger