### PR TITLE
fix: No test authentication call without a login

### DIFF
--- a/Model/Service/Authentication.php
+++ b/Model/Service/Authentication.php
@@ -17,6 +17,6 @@ class Authentication
 
     public function test($userId, $key)
     {
-        return $this->connector->testAuthenticate($userId, $key);
+        return isset($userId, $key) ? $this->connector->testAuthenticate($userId, $key) : false;
     }
 }

--- a/Observer/AdminLogin.php
+++ b/Observer/AdminLogin.php
@@ -45,7 +45,9 @@ class AdminLogin implements \Magento\Framework\Event\ObserverInterface
         }
 
         // the configs here dont use
-        $response = $this->connector->testAuthenticate($this->helper->getConfigData('api/user'), $this->helper->getConfigData('api/key'));
+        $userId = $this->helper->getConfigData('api/user');
+        $key = $this->helper->getConfigData('api/key');
+        $response = (isset($userId, $key) ? $this->connector->testAuthenticate($userId, $key) : false);
         if ($response === false) {
             // invalid authentication message
             $this->notificationService->error(__('DHL Parcel extension has been turned on but user ID and API key combination is invalid'));


### PR DESCRIPTION
Calling `\DHLParcel\Shipping\Model\Api\Connector::testAuthenticate(...)` with a blank `$userId` / `$key` is wasting resources and triggers a Deprecated Functionality error on PHP 8.1:

Deprecated Functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated in ../vendor/dhlparcel/magento2-plugin/Model/Api/Connector.php on line 199