### PR TITLE
fix: Do not test authentication with a blank login

### DIFF
--- a/Model/Api/Connector.php
+++ b/Model/Api/Connector.php
@@ -195,7 +195,7 @@ class Connector
      */
     public function testAuthenticate($userId, $key)
     {
-        if (!isset($userId, $key) {
+        if (!isset($userId, $key)) {
             return false;
         }
         $response = $this->post(self::AUTH_API, [

--- a/Model/Api/Connector.php
+++ b/Model/Api/Connector.php
@@ -195,6 +195,9 @@ class Connector
      */
     public function testAuthenticate($userId, $key)
     {
+        if (!isset($userId, $key) {
+            return false;
+        }
         $response = $this->post(self::AUTH_API, [
             'userId' => trim($userId),
             'key'    => trim($key),


### PR DESCRIPTION
Do not test authentication when the userId or key is blank, this will also trigger a deprecated functionality error in PHP 8.1:

Deprecated Functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated in .../vendor/dhlparcel/magento2-plugin/Model/Api/Connector.php on line 199