### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/Block/Adminhtml/System/SameDayFieldCheck.php
+++ b/Block/Adminhtml/System/SameDayFieldCheck.php
@@ -23,7 +23,12 @@ class SameDayFieldCheck extends \Magento\Framework\Data\Form\Element\AbstractEle
     {
         $message = __('No shipping days have been set, for sameday to function this field is required');
         $shippingDays = $this->helper->getConfigData('delivery_times/shipping_days');
-        $shippingDays = is_string($shippingDays) ? explode(',', $shippingDays) : [];
+        if (is_string($shippingDays)) {
+            $shippingDays = explode(',', $shippingDays);
+        } else {
+            $shippingDays = [];
+        }
+        
         if (is_array($shippingDays) && count($shippingDays) > 0) {
             $message = '<span class="dhlparcel-sameday-check valid-shipping-days">' . $message . '</span>';
         } else {

--- a/Block/Adminhtml/System/SameDayFieldCheck.php
+++ b/Block/Adminhtml/System/SameDayFieldCheck.php
@@ -22,7 +22,8 @@ class SameDayFieldCheck extends \Magento\Framework\Data\Form\Element\AbstractEle
     public function getElementHtml()
     {
         $message = __('No shipping days have been set, for sameday to function this field is required');
-        $shippingDays = explode(',', $this->helper->getConfigData('delivery_times/shipping_days'));
+        $shippingDays = $this->helper->getConfigData('delivery_times/shipping_days');
+        $shippingDays = is_string($shippingDays) ? explode(',', $shippingDays) : [];
         if (is_array($shippingDays) && count($shippingDays) > 0) {
             $message = '<span class="dhlparcel-sameday-check valid-shipping-days">' . $message . '</span>';
         } else {


### PR DESCRIPTION
This the following error on a PHP 8.1 environment: Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/html/vendor/dhlparcel/magento2-plugin/Block/Adminhtml/System/SameDayFieldCheck.php on line 25