### PR TITLE
Added configurable option to default select first service point if none is selected

### DIFF
--- a/Model/Carrier.php
+++ b/Model/Carrier.php
@@ -317,7 +317,9 @@ class Carrier extends \Magento\Shipping\Model\Carrier\AbstractCarrierOnline impl
             }
 
             // Select default servicePoint if none is selected
-            if (!$servicePointId) {
+            $selectFirstByDefault = $this->getConfigData('shipping_methods/servicepoint/default_select_first');
+
+            if (!$servicePointId && $selectFirstByDefault) {
                 $toCountry = $request->getDestCountryId();
                 $toPostalCode = $request->getDestPostcode();
                 $servicePoint = $this->servicePointService->getClosest($toPostalCode, $toCountry);

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -738,6 +738,15 @@
                             <label>Title</label>
                             <comment>Leave empty to use default title</comment>
                         </field>
+                        <field id="default_select_first" translate="label" type="select" sortOrder="450" showInDefault="1"
+                               showInWebsite="1" showInStore="1">
+                            <label>Default select first servicepoint</label>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <comment>By enabling this option, if the customer is not selecting a service point, the most closeby service point will be selected.</comment>
+                            <depends>
+                                <field id="enabled">1</field>
+                            </depends>
+                        </field>
                         <field id="rate_method" translate="label" type="select" sortOrder="300" showInDefault="1"
                                showInWebsite="1" showInStore="1">
                             <label>Pricing method</label>


### PR DESCRIPTION
Hi,

For some countries, additional information is required. Two examples of these countries are Germany and Luxembourg. People here rent a service point box with a number, the so-called Post numbers.

Since you automatically select a service point at the API endpoint and do not have validation on this postal number, we are now receiving many complaints about orders without a postal number.

To prevent this, I have created a configurable option per store that can be turned on or off, so that the respective countries always need to select a service point themselves during checkout.

This ensures that the validation is now correct again, as a mandatory postal number must be filled in within the service point modal itself.

Hopefully, you can merge this code contribution quickly :)

Greetings,

Rakibabu