### PR TITLE
fix: Replace deprecated Zend version of JsonSerializable interface

### DIFF
--- a/Ui/Bulk/Actions.php
+++ b/Ui/Bulk/Actions.php
@@ -5,7 +5,7 @@ namespace DHLParcel\Shipping\Ui\Bulk;
 use DHLParcel\Shipping\Helper\Data;
 use Magento\Framework\UrlInterface;
 
-class Actions extends \Magento\Ui\DataProvider\AbstractDataProvider implements \Zend\Stdlib\JsonSerializable
+class Actions extends \Magento\Ui\DataProvider\AbstractDataProvider implements \JsonSerializable
 {
 
     protected $data;


### PR DESCRIPTION
This interface has been replaced with \JsonSerializable available since PHP 5.4.0. Magento 2.4.6-p4 deps do not include the \Zend\Stdlib\JsonSerializable interface any more.