### PR TITLE
Let DeliveryTimesPriority work with the current page layout

### DIFF
--- a/Ui/Column/DeliveryTimesPriority.php
+++ b/Ui/Column/DeliveryTimesPriority.php
@@ -4,26 +4,22 @@ namespace DHLParcel\Shipping\Ui\Column;
 
 use DHLParcel\Shipping\Model\Service\DeliveryTimes as DeliveryTimesService;
 use Magento\Sales\Api\OrderRepositoryInterface;
-use Magento\Framework\Controller\ResultFactory;
 
 class DeliveryTimesPriority extends \Magento\Ui\Component\Listing\Columns\Column
 {
     protected $deliveryTimesService;
     protected $orderRepository;
-    protected $resultFactory;
 
     public function __construct(
         \Magento\Framework\View\Element\UiComponent\ContextInterface $context,
         \Magento\Framework\View\Element\UiComponentFactory $uiComponentFactory,
         DeliveryTimesService $deliveryTimesService,
         OrderRepositoryInterface $orderRepository,
-        ResultFactory $resultFactory,
         array $components = [],
         array $data = []
     ) {
         $this->deliveryTimesService = $deliveryTimesService;
         $this->orderRepository = $orderRepository;
-        $this->resultFactory = $resultFactory;
         parent::__construct($context, $uiComponentFactory, $components, $data);
     }
 
@@ -68,9 +64,9 @@ class DeliveryTimesPriority extends \Magento\Ui\Component\Listing\Columns\Column
             'shipping_advice_class' => $shippingAdviceClass,
         ];
 
-        return $this->resultFactory->create(\Magento\Framework\Controller\ResultFactory::TYPE_LAYOUT)
-            ->getLayout()
-            ->createBlock('Magento\Framework\View\Element\Template', 'deliverytimes.column.' . mt_rand()) // phpcs:ignore
+        return $this->context
+            ->getPageLayout()
+            ->createBlock(\Magento\Backend\Block\Template::class, 'deliverytimes.column.' . mt_rand()) // phpcs:ignore
             ->setData($view)
             ->setTemplate('DHLParcel_Shipping::deliverytimes.column.phtml')
             ->setArea(\Magento\Framework\App\Area::AREA_ADMINHTML)


### PR DESCRIPTION
The current code crashed my order overview; since some 'content'-alike elements were missing on the page. Upon debugging, I found that the createBlock() statement created this exception. By using the current page layout and the default admin block class, we prevent using the resultfactory (which gives weird behaviour since it generates a result)