### PR TITLE
fix: make ImportRate constructor PHP 8.4 compatible

### DIFF
--- a/Model/Config/Backend/ImportRate.php
+++ b/Model/Config/Backend/ImportRate.php
@@ -17,8 +17,8 @@ class ImportRate extends \Magento\Framework\App\Config\Value
         \Magento\Framework\App\Config\ScopeConfigInterface $config,
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         RateManagerFactory $rateManagerFactory,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->rateManagerFactory = $rateManagerFactory;


### PR DESCRIPTION
On PHP 8.4, implicit nullable parameters are deprecated and can break Magento commands in stricter environments. This change prevents that warning/error.